### PR TITLE
package.json modified to run OS-specific versions of tar for Mac (usi…

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,15 @@
     "dev": "vite",
     "start": "vite preview",
     "compile": "tsc -b && vite build",
-    "dist": "rm -f ./dist/*.gz ; tar -s \"/^dist/ff3-ofx/\" -cvzf dist/ff3-ofx-${npm_package_version}.tar.gz dist/*",
+    "dist": "rm -f ./dist/*.gz ; tar -cvzf dist/ff3-ofx-${npm_package_version}.tar.gz dist/*",
+    "dist:mac": {
+      "os": "darwin",
+      "command": "rm -f ./dist/*.gz ; tar -s \"/^dist/ff3-ofx/\" -cvzf dist/ff3-ofx-${npm_package_version}.tar.gz dist/*"
+    },
+    "dist:linux": {
+      "os": "linux",
+      "command": "rm -f ./dist/*.gz ; tar -cvzf dist/ff3-ofx-${npm_package_version}.tar.gz dist/*"
+    },
     "package": "rm -rf ./dist/* ; yarn compile && yarn dist",
     "test": "vitest",
     "lint": "eslint src --ext js,jsx --report-unused-disable-directives --max-warnings 0",


### PR DESCRIPTION
This updates package.json to allow "yarn dist" to run under Linux, addressing the comment:

> Note that the tar command is MacOS specific and may not work on other Linux platforms.

The previous (Mac-specific) tar command remains the default if an OS-specific branch is not followed. No Windows varient given, but it could be added by someone with access to Windows. The Mac branch is really just a placeholder, hard-coded with "darwin" as the OS version. It should be generalized from darwin to all OSX, but lacking access to an OSX platform, I cannot easily test this.